### PR TITLE
refactor: move bluetooth code out of cosmic-settings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,17 +19,20 @@ tokio = { version = "1.39.3", features = ["net", "process", "sync"] }
 tokio-stream = "0.1.15"
 tracing = "0.1.40"
 upower_dbus = { git = "https://github.com/pop-os/dbus-settings-bindings", optional = true }
+bluez-zbus = { git = "https://github.com/pop-os/dbus-settings-bindings", optional = true }
 zbus = "4.4.0"
 
 [features]
 default = [
     "airplane_mode",
+    "bluetooth",
     "network_manager",
     "pulse",
     "upower",
     "settings_daemon",
 ]
 airplane_mode = ["rustix"]
+bluetooth = ["dep:bluez-zbus"]
 network_manager = ["dep:cosmic-dbus-networkmanager", "dep:secure-string"]
 pipewire = ["dep:pipewire"]
 pulse = ["libpulse-binding"]

--- a/src/bluetooth/adapter.rs
+++ b/src/bluetooth/adapter.rs
@@ -1,0 +1,315 @@
+// Copyright 2024 System76 <info@system76.com>
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::bluetooth::{Active, Event};
+use std::{
+    collections::HashMap,
+    hash::{Hash, Hasher},
+    time::Duration,
+};
+use zbus::zvariant::OwnedObjectPath;
+
+#[derive(Default, Debug, Clone)]
+pub struct Adapter {
+    pub alias: String,
+    pub address: String,
+    pub scanning: Active,
+    pub enabled: Active,
+}
+
+impl Hash for Adapter {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.address.hash(state);
+    }
+}
+
+impl PartialEq for Adapter {
+    fn eq(&self, other: &Self) -> bool {
+        self.address == other.address
+    }
+}
+
+impl Eq for Adapter {}
+
+impl Adapter {
+    pub async fn from_device(
+        proxy: &bluez_zbus::adapter1::Adapter1Proxy<'_>,
+    ) -> zbus::Result<Self> {
+        let (address, alias, scanning, enabled) = futures::try_join!(
+            proxy.address(),
+            proxy.alias(),
+            async {
+                Ok(
+                    if proxy.discoverable().await? && proxy.discovering().await? {
+                        Active::Enabled
+                    } else {
+                        Active::Disabled
+                    },
+                )
+            },
+            async {
+                Ok(if proxy.powered().await? {
+                    Active::Enabled
+                } else {
+                    Active::Disabled
+                })
+            }
+        )?;
+
+        Ok(Self {
+            alias,
+            address,
+            scanning,
+            enabled,
+        })
+    }
+
+    pub fn update(&mut self, updates: Vec<AdapterUpdate>) {
+        for update in updates {
+            match update {
+                AdapterUpdate::Alias(alias) => self.alias = alias,
+                AdapterUpdate::Address(address) => self.address = address,
+                AdapterUpdate::Enabled(enabled) => {
+                    self.enabled = match (self.enabled, enabled) {
+                        (Active::Enabling, Active::Enabled) => Active::Enabled,
+                        (Active::Disabling, Active::Disabled) => Active::Disabled,
+                        (Active::Enabled | Active::Disabled, status) => status,
+                        (status, _) => status,
+                    }
+                }
+                AdapterUpdate::Scanning(scanning) => {
+                    self.scanning = match (self.scanning, scanning) {
+                        (Active::Enabling, Active::Enabled) => Active::Enabled,
+                        (Active::Disabling, Active::Disabled) => Active::Disabled,
+                        (Active::Enabled | Active::Disabled, status) => status,
+                        (status, _) => status,
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum AdapterUpdate {
+    Alias(String),
+    Address(String),
+    Scanning(Active),
+    Enabled(Active),
+}
+
+impl AdapterUpdate {
+    #[must_use]
+    pub fn from_update(update: HashMap<&'_ str, zbus::zvariant::Value<'_>>) -> Vec<Self> {
+        update
+            .into_iter()
+            .filter_map(|(key, value)| {
+                match (key, value) {
+                    ("Alias", zbus::zvariant::Value::Str(value)) => Some(Self::Alias(value.into())),
+                    ("Discovering" | "Discoverable", zbus::zvariant::Value::Bool(value)) => {
+                        Some(Self::Scanning(if value {
+                            Active::Enabled
+                        } else {
+                            Active::Disabled
+                        }))
+                    }
+                    ("Powered", zbus::zvariant::Value::Bool(value)) => {
+                        Some(Self::Enabled(if value {
+                            Active::Enabled
+                        } else {
+                            Active::Disabled
+                        }))
+                    }
+                    ("Address", zbus::zvariant::Value::Str(value)) => {
+                        Some(Self::Address(value.into()))
+                    }
+                    // Battery
+                    (message, value) => {
+                        tracing::error!(message, ?value, "adapter update");
+                        None
+                    }
+                }
+            })
+            .collect()
+    }
+}
+
+pub async fn start_discovery(connection: zbus::Connection, adapter_path: OwnedObjectPath) -> Event {
+    let result: zbus::Result<()> = Ok(());
+
+    let adapter = match bluez_zbus::get_adapter(&connection, adapter_path).await {
+        Err(why) => {
+            tracing::error!("Unable to get the adapter: {why}");
+            return Event::DBusError(why.to_string());
+        }
+        Ok(adapter) => adapter,
+    };
+
+    for attempt in 1..5 {
+        let result = async {
+            tracing::debug!("Starting discovery");
+            // We don't seem to be able to use join here as it seem to lead to some kind of race condition and not start scanning occasionally
+            adapter.set_pairable(true).await?;
+            adapter.set_discoverable(true).await?;
+            if adapter.discovering().await? {
+                return Ok(());
+            }
+            adapter.start_discovery().await
+        }
+        .await;
+
+        if let Err(why) = result {
+            tracing::warn!("Unable to start bluetooth scanning: {why}");
+            tokio::time::sleep(Duration::from_millis(1000 * attempt)).await;
+        } else {
+            tracing::debug!("Discovery started");
+            return Event::Ok;
+        }
+    }
+
+    if let Err(why) = result {
+        Event::DBusError(why.to_string())
+    } else {
+        Event::Ok
+    }
+}
+
+pub async fn stop_discovery(connection: zbus::Connection, adapter_path: OwnedObjectPath) -> Event {
+    let result: zbus::Result<()> = Ok(());
+
+    let adapter = match bluez_zbus::get_adapter(&connection, adapter_path).await {
+        Err(why) => return Event::DBusError(format!("Unable to get the adapter: {why}")),
+        Ok(adapter) => adapter,
+    };
+
+    for attempt in 1..5 {
+        let result = async {
+            tracing::debug!("Stopping discovery");
+
+            // We don't seem to be able to use join here as it seem to lead to some kind of race condition and not stop scanning occasionally
+            adapter.set_pairable(false).await?;
+            adapter.set_discoverable(false).await?;
+            if adapter.discovering().await? {
+                adapter.stop_discovery().await
+            } else {
+                Ok(())
+            }
+        }
+        .await;
+
+        if let Err(why) = result {
+            tracing::warn!("Unable to stop bluetooth scanning: {why}");
+            tokio::time::sleep(Duration::from_millis(1000 * attempt)).await;
+        } else {
+            tracing::debug!("Discovery stopped");
+            return Event::Ok;
+        }
+    }
+
+    if let Err(why) = result {
+        return Event::DBusError(why.to_string());
+    }
+    Event::Ok
+}
+
+pub async fn change_adapter_status(
+    connection: zbus::Connection,
+    adapter_path: OwnedObjectPath,
+    active: bool,
+) -> Event {
+    let mut result: zbus::Result<()> = Ok(());
+    for attempt in 1..5 {
+        result = async {
+            let adapter = bluez_zbus::get_adapter(&connection, adapter_path.clone()).await?;
+            if active {
+                adapter.set_powered(true).await?;
+                adapter.set_discoverable(true).await
+            } else {
+                if let Err(why) = adapter.set_discoverable(false).await {
+                    tracing::warn!("Unable to change discoverability: {why}");
+                }
+                adapter.set_powered(false).await
+            }
+        }
+        .await;
+        if let Err(why) = &result {
+            tracing::warn!("Unable to change the adapter state: {why}");
+            tokio::time::sleep(Duration::from_millis(1000 * attempt)).await;
+        } else {
+            return Event::Ok;
+        }
+    }
+
+    if let Err(why) = result {
+        tracing::error!("Failed to change the adapter state!");
+        return Event::DBusError(why.to_string());
+    }
+
+    Event::Ok
+}
+
+pub async fn get_adapters(connection: zbus::Connection) -> Event {
+    let result: zbus::Result<HashMap<OwnedObjectPath, Adapter>> = async {
+        futures::future::join_all(
+            bluez_zbus::get_adapters(&connection)
+                .await?
+                .into_iter()
+                .map(|(path, proxy)| async move {
+                    Ok((path.to_owned(), Adapter::from_device(&proxy).await?))
+                }),
+        )
+        .await
+        .into_iter()
+        .collect::<zbus::Result<HashMap<_, _>>>()
+    }
+    .await;
+    match result {
+        Ok(adapters) => Event::SetAdapters(adapters),
+        Err(why) => {
+            tracing::error!("dbus connection failed. {why}");
+            Event::DBusError(why.to_string())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_adapter_device_with_intermediary_state() {
+        let mut adapter = Adapter {
+            alias: "foo".to_owned(),
+            address: "AA:BB:CC:DD:EE:FF".to_owned(),
+            scanning: Active::Disabled,
+            enabled: Active::Disabled,
+        };
+        adapter.update(vec![
+            AdapterUpdate::Enabled(Active::Enabled),
+            AdapterUpdate::Alias("xxx".to_owned()),
+        ]);
+        assert_eq!(adapter.enabled, Active::Enabled);
+        assert_eq!(&adapter.alias, "xxx");
+
+        adapter.enabled = Active::Disabling;
+        adapter.update(vec![
+            AdapterUpdate::Enabled(Active::Enabled),
+            AdapterUpdate::Alias("xxx".to_owned()),
+        ]);
+        assert_eq!(adapter.enabled, Active::Disabling);
+
+        adapter.scanning = Active::Enabling;
+        adapter.update(vec![
+            AdapterUpdate::Scanning(Active::Disabled),
+            AdapterUpdate::Alias("xxx".to_owned()),
+        ]);
+        assert_eq!(adapter.scanning, Active::Enabling);
+
+        adapter.update(vec![
+            AdapterUpdate::Scanning(Active::Enabled),
+            AdapterUpdate::Alias("xxx".to_owned()),
+        ]);
+        assert_eq!(adapter.scanning, Active::Enabled);
+        assert_eq!(&adapter.alias, "xxx");
+    }
+}

--- a/src/bluetooth/agent.rs
+++ b/src/bluetooth/agent.rs
@@ -1,0 +1,67 @@
+// Copyright 2024 System76 <info@system76.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use crate::bluetooth::Event;
+
+use std::sync::Arc;
+
+use futures::{SinkExt, StreamExt};
+use zbus::zvariant::ObjectPath;
+
+const AGENT_PATH: &str = "/org/bluez/agent/cosmic_settings";
+
+pub async fn unregister(connection: zbus::Connection) -> zbus::Result<()> {
+    let agent_path = ObjectPath::from_static_str_unchecked(AGENT_PATH);
+    let bluez = bluez_zbus::agent_manager1::AgentManager1Proxy::new(&connection).await?;
+    bluez.unregister_agent(&agent_path).await
+}
+
+pub async fn watch(
+    connection: zbus::Connection,
+    mut tx: futures::channel::mpsc::Sender<Event>,
+) -> zbus::Result<()> {
+    let span = tracing::span!(tracing::Level::INFO, "bluetooth::agent::watch");
+    let _span = span.enter();
+
+    let (agent, mut receiver) = bluez_zbus::agent1::create();
+
+    let agent_path = ObjectPath::from_static_str_unchecked(AGENT_PATH);
+
+    tracing::debug!("connecting agent");
+
+    connection.object_server().at(&agent_path, agent).await?;
+
+    tracing::debug!("connecting to bluez agent manager");
+
+    let bluez = bluez_zbus::agent_manager1::AgentManager1Proxy::new(&connection).await?;
+
+    tracing::debug!("registering agent");
+
+    bluez
+        .register_agent(
+            &agent_path,
+            <&'static str>::from(bluez_zbus::agent1::Capability::DisplayYesNo),
+        )
+        .await?;
+
+    if let Err(why) = bluez.request_default_agent(&agent_path).await {
+        _ = bluez.unregister_agent(&agent_path).await;
+        Err(why)?;
+    }
+
+    tracing::debug!("registered");
+
+    while let Some(msg) = receiver.next().await {
+        tracing::debug!(?msg, "agent message received");
+
+        if tx.send(Event::Agent(Arc::new(msg))).await.is_err() {
+            break;
+        }
+    }
+
+    _ = bluez.unregister_agent(&agent_path).await;
+
+    tracing::debug!("exiting");
+
+    Ok(())
+}

--- a/src/bluetooth/device.rs
+++ b/src/bluetooth/device.rs
@@ -1,0 +1,374 @@
+// Copyright 2024 System76 <info@system76.com>
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::bluetooth::{Active, Event};
+use futures::join;
+use std::{
+    collections::HashMap,
+    hash::{Hash, Hasher},
+    time::Duration,
+};
+use zbus::zvariant::OwnedObjectPath;
+
+const DEFAILT_DEVICE_ICON: &str = "bluetooth-symbolic";
+
+// Copied from https://github.com/bluez/bluez/blob/39467578207889fd015775cbe81a3db9dd26abea/src/dbus-common.c#L53
+fn device_type_to_icon(device_type: &str) -> &'static str {
+    match device_type {
+        "computer" => "laptop-symbolic",
+        "phone" => "smartphone-symbolic",
+        "network-wireless" => "network-wireless-symbolic",
+        "audio-headset" => "audio-headset-symbolic",
+        "audio-headphones" => "audio-headphones-symbolic",
+        "camera-video" => "camera-video-symbolic",
+        "audio-card" => "audio-card-symbolic",
+        "input-gaming" => "input-gaming-symbolic",
+        "input-keyboard" => "input-keyboard-symbolic",
+        "input-tablet" => "input-tablet-symbolic",
+        "input-mouse" => "input-mouse-symbolic",
+        "printer" => "printer-network-symbolic",
+        "camera-photo" => "camera-photo-symbolic",
+        _ => DEFAILT_DEVICE_ICON,
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct Device {
+    alias: Option<String>,
+    pub address: String,
+    pub adapter: OwnedObjectPath,
+    pub enabled: Active,
+    pub paired: bool,
+    pub icon: &'static str,
+    pub battery: Option<String>,
+}
+
+impl Device {
+    pub async fn from_device(proxy: &bluez_zbus::BluetoothDevice<'_>) -> zbus::Result<Self> {
+        let (address, adapter, alias) = join!(
+            proxy.device.address(),
+            proxy.device.adapter(),
+            proxy.device.name()
+        );
+        let address = address?;
+        if address.is_empty() {
+            return Err(zbus::Error::Failure("Device has no MAC address".to_owned()));
+        }
+        let adapter = adapter?;
+        if adapter.is_empty() {
+            return Err(zbus::Error::Failure("Device has no adapter".to_owned()));
+        }
+        let alias = alias.ok();
+        let device_type: String = proxy.icon().await;
+        let paired = proxy.device.paired().await.unwrap_or(false);
+        let enabled = if proxy.device.connected().await.unwrap_or(false) && paired {
+            Active::Enabled
+        } else {
+            Active::Disabled
+        };
+        let battery = match &proxy.battery {
+            Some(battery) => match battery.percentage().await {
+                Ok(percentage) => Some(percentage.to_string()),
+                Err(why) => {
+                    eprintln!("couldn't fetch battery percentage: {why}");
+                    None
+                }
+            },
+            None => None,
+        };
+
+        let icon = device_type_to_icon(device_type.as_str());
+
+        Ok(Self {
+            alias,
+            address,
+            adapter,
+            enabled,
+            paired,
+            icon,
+            battery,
+        })
+    }
+    #[must_use]
+    pub fn is_connected(&self) -> bool {
+        self.enabled == Active::Enabled
+    }
+    /// Update the state of the device without overriding intermediary states.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the device used for update doesn't have the same MAC address
+    pub fn update(&mut self, updates: Vec<DeviceUpdate>) {
+        for udpate in updates {
+            match udpate {
+                DeviceUpdate::Alias(alias) => self.alias = alias,
+                DeviceUpdate::Enabled(enabled) => {
+                    self.enabled = match (self.enabled, enabled) {
+                        (Active::Enabling, Active::Enabled) => Active::Enabled,
+                        (Active::Disabling, Active::Disabled) => Active::Disabled,
+                        (Active::Enabled | Active::Disabled, status) => status,
+                        (status, _) => status,
+                    }
+                }
+                DeviceUpdate::Paired(paired) => {
+                    self.enabled = Active::Disabling;
+                    self.paired = paired;
+                }
+                DeviceUpdate::Icon(icon) => self.icon = icon,
+                DeviceUpdate::Battery(battery) => self.battery = battery,
+            }
+        }
+        if self.enabled == Active::Disabled {
+            self.battery = None;
+        }
+    }
+    #[must_use]
+    pub fn has_alias(&self) -> bool {
+        self.alias.is_some()
+    }
+    #[must_use]
+    pub fn is_known_device_type(&self) -> bool {
+        self.icon != DEFAILT_DEVICE_ICON
+    }
+    #[must_use]
+    pub fn alias_or_addr(&self) -> &str {
+        self.alias.as_ref().unwrap_or(&self.address)
+    }
+}
+
+impl Hash for Device {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.address.hash(state);
+    }
+}
+
+impl PartialEq for Device {
+    fn eq(&self, other: &Self) -> bool {
+        self.address == other.address
+    }
+}
+
+impl Eq for Device {}
+
+#[derive(Debug, Clone)]
+pub enum DeviceUpdate {
+    Alias(Option<String>),
+    Enabled(Active),
+    Paired(bool),
+    Icon(&'static str),
+    Battery(Option<String>),
+}
+
+impl DeviceUpdate {
+    pub fn from_update(update: HashMap<&'_ str, zbus::zvariant::Value<'_>>) -> Vec<Self> {
+        update
+            .into_iter()
+            .filter_map(|(key, value)| {
+                match (key, value) {
+                    ("Alias", zbus::zvariant::Value::Str(value)) => {
+                        Some(DeviceUpdate::Alias(Some(value.into())))
+                    }
+                    ("Connected", zbus::zvariant::Value::Bool(value)) => {
+                        Some(DeviceUpdate::Enabled(if value {
+                            Active::Enabled
+                        } else {
+                            Active::Disabled
+                        }))
+                    }
+                    ("Paired", zbus::zvariant::Value::Bool(value)) => {
+                        Some(DeviceUpdate::Paired(value))
+                    }
+                    ("Icon", zbus::zvariant::Value::Str(value)) => {
+                        Some(DeviceUpdate::Icon(device_type_to_icon(&value)))
+                    }
+                    ("Percentage", zbus::zvariant::Value::U8(percentage)) => {
+                        Some(DeviceUpdate::Battery(Some(percentage.to_string())))
+                    }
+                    // Battery
+                    (message, value) => {
+                        tracing::debug!(message, ?value, "device update");
+                        None
+                    }
+                }
+            })
+            .collect()
+    }
+}
+
+pub async fn disconnect_device(
+    connection: zbus::Connection,
+    device_path: OwnedObjectPath,
+) -> Event {
+    let proxy = match bluez_zbus::get_device(&connection, device_path.clone()).await {
+        Err(why) => {
+            tracing::error!("Unable to get the device: {why}");
+            return Event::DeviceFailed(device_path);
+        }
+        Ok(proxy) => proxy,
+    };
+
+    for attempt in 1..5 {
+        let result = async {
+            if !proxy.device.connected().await? {
+                return Ok(());
+            }
+
+            proxy.device.disconnect().await
+        }
+        .await;
+
+        if let Err(why) = result {
+            tracing::warn!("Unable to disconnect to device: {why}");
+            tokio::time::sleep(Duration::from_millis(1000 * attempt)).await;
+        } else {
+            return Event::Ok;
+        }
+    }
+
+    Event::DeviceFailed(device_path)
+}
+
+pub async fn connect_device(connection: zbus::Connection, device_path: OwnedObjectPath) -> Event {
+    let proxy = match bluez_zbus::get_device(&connection, device_path.clone()).await {
+        Err(why) => {
+            tracing::error!("Unable to get the device: {why}");
+            return Event::DeviceFailed(device_path);
+        }
+        Ok(proxy) => proxy,
+    };
+
+    for attempt in 1..5 {
+        let result = async {
+            if proxy.device.connected().await? {
+                Ok(())
+            } else {
+                proxy.device.connect().await
+            }
+        }
+        .await;
+
+        if let Err(why) = result {
+            tracing::warn!("Unable to connect to device: {why}");
+            tokio::time::sleep(Duration::from_millis(1000 * attempt)).await;
+        } else {
+            return Event::Ok;
+        }
+    }
+
+    Event::DeviceFailed(device_path)
+}
+
+pub async fn forget_device(connection: zbus::Connection, device_path: OwnedObjectPath) -> Event {
+    let mut result: zbus::Result<()> = Ok(());
+
+    let proxy = match bluez_zbus::get_device(&connection, device_path.clone()).await {
+        Err(why) => {
+            tracing::error!("Unable to get the device: {why}");
+            return Event::DeviceFailed(device_path);
+        }
+        Ok(proxy) => proxy,
+    };
+
+    let adapter_path = match proxy.device.adapter().await {
+        Err(why) => {
+            tracing::error!("Unable to get the adapter: {why}");
+            return Event::DeviceFailed(device_path);
+        }
+        Ok(adapter_path) => adapter_path,
+    };
+
+    let adapter = match bluez_zbus::get_adapter(&connection, adapter_path).await {
+        Err(why) => {
+            tracing::error!("Unable to get the adapter: {why}");
+            return Event::DeviceFailed(device_path);
+        }
+        Ok(adapter) => adapter,
+    };
+
+    for attempt in 1..5 {
+        result = async {
+            if proxy.device.connected().await? {
+                proxy.device.disconnect().await?;
+            }
+
+            adapter.remove_device(&proxy.path()).await
+        }
+        .await;
+
+        if let Err(why) = &result {
+            tracing::warn!("Unable to connect to device: {why}");
+            tokio::time::sleep(Duration::from_millis(1000 * attempt)).await;
+        } else {
+            return Event::Ok;
+        }
+    }
+
+    if result.is_err() {
+        Event::DeviceFailed(device_path)
+    } else {
+        Event::Ok
+    }
+}
+
+pub async fn get_devices(connection: zbus::Connection, adapter_path: OwnedObjectPath) -> Event {
+    // TODO error handling
+    let result: zbus::Result<HashMap<OwnedObjectPath, Device>> = async {
+        futures::future::join_all(
+            bluez_zbus::get_devices(&connection, Some(&adapter_path))
+                .await?
+                .into_iter()
+                .map(
+                    |(path, device)| async move { Ok((path, Device::from_device(&device).await?)) },
+                ),
+        )
+        .await
+        .into_iter()
+        .collect::<Result<HashMap<_, _>, _>>()
+    }
+    .await;
+    match result {
+        Ok(devices) => Event::SetDevices(devices),
+        Err(why) => {
+            tracing::error!("zbus connection failed. {why}");
+            Event::DBusError(why.to_string())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_update_device_with_intermediary_state() {
+        let mut device = Device {
+            alias: None,
+            adapter: OwnedObjectPath::try_from("/dev/bluez/hci0").unwrap(),
+            address: "AA:BB:CC:DD:EE:FF".to_owned(),
+            enabled: Active::Disabled,
+            paired: false,
+            icon: "bluetooth-symbolic",
+            battery: None,
+        };
+        device.update(vec![
+            DeviceUpdate::Enabled(Active::Enabled),
+            DeviceUpdate::Alias(Some("Foo".to_owned())),
+        ]);
+        assert_eq!(device.enabled, Active::Enabled);
+        assert_eq!(device.alias, Some("Foo".to_owned()));
+
+        device.enabled = Active::Disabling;
+        device.update(vec![
+            DeviceUpdate::Enabled(Active::Enabled),
+            DeviceUpdate::Alias(Some("Foo".to_owned())),
+        ]);
+        assert_eq!(device.enabled, Active::Disabling);
+
+        device.enabled = Active::Enabling;
+        device.update(vec![
+            DeviceUpdate::Enabled(Active::Enabled),
+            DeviceUpdate::Alias(Some("Foo".to_owned())),
+        ]);
+        assert_eq!(device.enabled, Active::Enabled);
+    }
+}

--- a/src/bluetooth/mod.rs
+++ b/src/bluetooth/mod.rs
@@ -4,8 +4,10 @@
 use std::collections::HashMap;
 use zbus::zvariant::OwnedObjectPath;
 
+mod adapter;
 mod device;
 
+pub use adapter::*;
 pub use device::*;
 
 #[derive(Clone, Debug)]
@@ -13,6 +15,7 @@ pub enum Event {
     DBusError(String),
     DeviceFailed(OwnedObjectPath),
     Ok,
+    SetAdapters(HashMap<OwnedObjectPath, Adapter>),
     SetDevices(HashMap<OwnedObjectPath, Device>),
 }
 

--- a/src/bluetooth/mod.rs
+++ b/src/bluetooth/mod.rs
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use zbus::zvariant::OwnedObjectPath;
 
 mod adapter;
+pub mod agent;
 mod device;
 pub mod subscription;
 
@@ -15,6 +17,7 @@ pub use device::*;
 pub enum Event {
     AddedAdapter(OwnedObjectPath, Adapter),
     AddedDevice(OwnedObjectPath, Device),
+    Agent(Arc<bluez_zbus::agent1::Message>),
     DBusError(String),
     DBusServiceUnknown,
     DeviceFailed(OwnedObjectPath),

--- a/src/bluetooth/mod.rs
+++ b/src/bluetooth/mod.rs
@@ -6,17 +6,25 @@ use zbus::zvariant::OwnedObjectPath;
 
 mod adapter;
 mod device;
+pub mod subscription;
 
 pub use adapter::*;
 pub use device::*;
 
 #[derive(Clone, Debug)]
 pub enum Event {
+    AddedAdapter(OwnedObjectPath, Adapter),
+    AddedDevice(OwnedObjectPath, Device),
     DBusError(String),
+    DBusServiceUnknown,
     DeviceFailed(OwnedObjectPath),
     Ok,
+    RemovedAdapter(OwnedObjectPath),
+    RemovedDevice(OwnedObjectPath),
     SetAdapters(HashMap<OwnedObjectPath, Adapter>),
     SetDevices(HashMap<OwnedObjectPath, Device>),
+    UpdatedAdapter(OwnedObjectPath, Vec<AdapterUpdate>),
+    UpdatedDevice(OwnedObjectPath, Vec<DeviceUpdate>),
 }
 
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]

--- a/src/bluetooth/mod.rs
+++ b/src/bluetooth/mod.rs
@@ -1,0 +1,26 @@
+// Copyright 2024 System76 <info@system76.com>
+// SPDX-License-Identifier: MPL-2.0
+
+use std::collections::HashMap;
+use zbus::zvariant::OwnedObjectPath;
+
+mod device;
+
+pub use device::*;
+
+#[derive(Clone, Debug)]
+pub enum Event {
+    DBusError(String),
+    DeviceFailed(OwnedObjectPath),
+    Ok,
+    SetDevices(HashMap<OwnedObjectPath, Device>),
+}
+
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+pub enum Active {
+    #[default]
+    Disabled,
+    Disabling,
+    Enabling,
+    Enabled,
+}

--- a/src/bluetooth/subscription.rs
+++ b/src/bluetooth/subscription.rs
@@ -1,0 +1,221 @@
+// Copyright 2024 System76 <info@system76.com>
+// SPDX-License-Identifier: MPL-2.0
+
+use crate::bluetooth::{AdapterUpdate, Device, DeviceUpdate, Event};
+use std::pin::Pin;
+
+use bluez_zbus::BluetoothDevice;
+use futures::{channel::mpsc, stream::FusedStream};
+use iced_futures::futures::{SinkExt, StreamExt};
+use zbus::{fdo, zvariant::OwnedObjectPath};
+
+enum DevicePropertyWatcherTask {
+    Add(OwnedObjectPath),
+    Removed(OwnedObjectPath),
+}
+
+struct DevicePropertyWatcher<'a> {
+    stream: futures::stream::SelectAll<SignalWatcher<'a>>,
+    rx: mpsc::Receiver<DevicePropertyWatcherTask>,
+}
+
+struct SignalWatcher<'a> {
+    stream: zbus::fdo::PropertiesChangedStream<'a>,
+    path: OwnedObjectPath,
+}
+
+impl<'a> futures::Stream for SignalWatcher<'a> {
+    type Item = zbus::fdo::PropertiesChanged;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        futures::Stream::poll_next(Pin::new(&mut self.stream), cx)
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.stream.size_hint()
+    }
+}
+
+impl<'a> DevicePropertyWatcher<'a> {
+    fn new() -> (Self, mpsc::Sender<DevicePropertyWatcherTask>) {
+        let stream = futures::stream::select_all(vec![]);
+        let (tx, rx) = mpsc::channel(10);
+
+        (Self { stream, rx }, tx)
+    }
+    async fn insert(
+        &mut self,
+        connection: &zbus::Connection,
+        path: OwnedObjectPath,
+    ) -> zbus::Result<()> {
+        if let Some(signal) = self.stream.iter_mut().find(|s| s.path.eq(&path)) {
+            if signal.stream.is_terminated() {
+                let property_proxy =
+                    zbus::fdo::PropertiesProxy::new(connection, "org.bluez", path.clone()).await?;
+                signal.stream = property_proxy.receive_properties_changed().await?;
+            }
+            return Ok(());
+        }
+        let property_proxy =
+            zbus::fdo::PropertiesProxy::new(connection, "org.bluez", path.clone()).await?;
+        let stream = property_proxy.receive_properties_changed().await?;
+        self.stream.push(SignalWatcher { stream, path });
+        Ok(())
+    }
+    fn remove(mut self, path: &OwnedObjectPath) -> Self {
+        self.stream =
+            futures::stream::select_all(self.stream.into_iter().filter(|p| !p.path.eq(path)));
+        self
+    }
+}
+
+/// Watching new/removed devices, connected state changed
+pub async fn watch(connection: zbus::Connection, mut tx: futures::channel::mpsc::Sender<Event>) {
+    let span = tracing::span!(tracing::Level::INFO, "bluetooth::subscription::watch");
+    let _span = span.enter();
+
+    loop {
+        let result = async {
+            let managed_object_proxy =
+                zbus::fdo::ObjectManagerProxy::new(&connection, "org.bluez", "/")
+                    .await?;
+
+            let mut receive_interfaces_added = managed_object_proxy
+                .receive_interfaces_added()
+                .await?;
+            let mut receive_interfaces_removed = managed_object_proxy
+                .receive_interfaces_removed()
+                .await?;
+
+            let (mut property_watcher, mut property_watcher_task) = DevicePropertyWatcher::new();
+
+            for (path, interfaces) in managed_object_proxy.get_managed_objects().await? {
+                if interfaces.contains_key("org.bluez.Device1")
+                || interfaces.contains_key("org.bluez.Adapter1")
+                || interfaces.contains_key("org.bluez.Battery1")
+                {
+                    property_watcher.insert(&connection, path).await?;
+                }
+            }
+
+            while !property_watcher.rx.is_terminated() {
+                futures::select! {
+                    task = property_watcher.rx.next() => match task {
+                        Some(DevicePropertyWatcherTask::Add(path)) => {
+                            property_watcher.insert(&connection, path).await?;
+                        }
+                        Some(DevicePropertyWatcherTask::Removed(path)) => {
+                            property_watcher = property_watcher.remove(&path);
+                        }
+                        None => {
+                            tracing::error!("Bluetooth property watcher has shutdown unexpectedly");
+                        }
+                    },
+                    signal = property_watcher.stream.next() => match signal {
+                        Some(signal) => {
+                            let args = signal.args()?;
+                            let header = signal.message().header();
+                            match header.path() {
+                                Some(path) if path.contains("/dev_") =>
+                                    tx
+                                        .send(Event::UpdatedDevice(path.to_owned().into(), DeviceUpdate::from_update(args.changed_properties)))
+                                        .await
+                                        .map_err(|e| zbus::Error::Failure(e.to_string()))?,
+                                Some(path) => tx
+                                        .send(Event::UpdatedAdapter(path.to_owned().into(), AdapterUpdate::from_update(args.changed_properties)))
+                                        .await
+                                        .map_err(|e| zbus::Error::Failure(e.to_string()))?,
+                                None => continue
+                            }
+                        }
+                        None => {
+                            tracing::error!("Bluetooth object watcher has shutdown unexpectedly");
+                        }
+                    },
+                    signal = receive_interfaces_added.next() => match signal {
+                        Some(signal) => {
+                            let args = signal.args()?;
+                            match BluetoothDevice::new(&connection, args.object_path.clone()).await {
+                                Ok(device) => {
+                                    match Device::from_device(&device).await {
+                                        Ok(device) => {
+                                            property_watcher_task
+                                                .send(DevicePropertyWatcherTask::Add(args.object_path.to_owned().into())).await.map_err(|e| zbus::Error::Failure(e.to_string()))?;
+
+                                            tx
+                                                .send(Event::AddedDevice(args.object_path.to_owned().into(), device))
+                                                .await
+                                                .map_err(|e| zbus::Error::Failure(e.to_string()))?;
+
+                                        }
+                                        Err(why) => {
+                                            tracing::warn!("Cannot deserialise device: {why}");
+                                        }
+                                    }
+                                }
+                                Err(zbus::Error::InterfaceNotFound) => continue,
+                                Err(e) => return Err(e),
+                            }
+                        }
+                        None => {
+                            tracing::error!("Bluetooth object watcher has shutdown unexpectedly");
+                        }
+                    },
+                    signal = receive_interfaces_removed.next() => match signal {
+                        Some(signal) => {
+                            let args = signal.args()?;
+                            if args.interfaces.contains(&"org.bluez.Device1") {
+                                property_watcher_task.send(DevicePropertyWatcherTask::Removed(
+                                    args.object_path.to_owned().into(),
+                                )).await.map_err(|e| zbus::Error::Failure(e.to_string()))?;
+                                tx
+                                    .send(Event::RemovedDevice(args.object_path.to_owned().into()))
+                                    .await
+                                    .map_err(|e| zbus::Error::Failure(e.to_string()))?;
+
+                            } else if args.interfaces.contains(&"org.bluez.Battery1") {
+                                tx
+                                    .send(Event::UpdatedDevice(args.object_path.to_owned().into(), vec![DeviceUpdate::Battery(None)]))
+                                    .await
+                                    .map_err(|e| zbus::Error::Failure(e.to_string()))?;
+                            } else if args.interfaces.contains(&"org.bluez.Adapter1") {
+                                tx
+                                    .send(Event::RemovedAdapter(args.object_path.to_owned().into()))
+                                    .await
+                                    .map_err(|e| zbus::Error::Failure(e.to_string()))?;
+                            }
+                        },
+                        None => {
+                            tracing::error!("Bluetooth object watcher has shutdown unexpectedly");
+                        }
+                    },
+                }
+            }
+            tracing::warn!("bluetooth event loop gracefully terminated");
+            Ok(())
+        }.await;
+
+        if let Err(why) = result {
+            _ = tx.send(Event::DBusError(why.to_string())).await;
+
+            tracing::error!("failed to watch bluetooth event: {why}.");
+
+            // Exit if the dbus service is not found.
+            if let zbus::Error::FDO(fdo_error) = why {
+                match *fdo_error {
+                    fdo::Error::ServiceUnknown(_) => {
+                        tracing::error!(
+                            "The org.bluez dbus service is unknown. Is the bluez service installed and activatable?"
+                        );
+                        _ = tx.send(Event::DBusServiceUnknown).await;
+                        return;
+                    }
+
+                    _ => (),
+                }
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@ pub mod pipewire;
 #[cfg(feature = "pulse")]
 pub mod pulse;
 
+#[cfg(feature = "bluetooth")]
+pub mod bluetooth;
+
 #[cfg(feature = "settings_daemon")]
 pub mod settings_daemon;
 


### PR DESCRIPTION
This is the first PR to extract the bluetooth code from [cosmic-settings](https://github.com/pop-os/cosmic-settings/tree/master/cosmic-settings/src/pages/bluetooth) so that it can also be used by [cosmic-applet-bluetooth](https://github.com/pop-os/cosmic-applets/tree/master/cosmic-applet-bluetooth).

I kept the code as close as possible to its original state, making only necessary modifications.