### PR TITLE
Bluetooth subscription improvements

### DIFF
--- a/src/bluetooth/adapter.rs
+++ b/src/bluetooth/adapter.rs
@@ -140,7 +140,7 @@ pub async fn start_discovery(connection: zbus::Connection, adapter_path: OwnedOb
     let adapter = match bluez_zbus::get_adapter(&connection, adapter_path).await {
         Err(why) => {
             tracing::error!("Unable to get the adapter: {why}");
-            return Event::DBusError(why.to_string());
+            return Event::DBusError(why);
         }
         Ok(adapter) => adapter,
     };
@@ -168,7 +168,7 @@ pub async fn start_discovery(connection: zbus::Connection, adapter_path: OwnedOb
     }
 
     if let Err(why) = result {
-        Event::DBusError(why.to_string())
+        Event::DBusError(why)
     } else {
         Event::Ok
     }
@@ -178,7 +178,7 @@ pub async fn stop_discovery(connection: zbus::Connection, adapter_path: OwnedObj
     let result: zbus::Result<()> = Ok(());
 
     let adapter = match bluez_zbus::get_adapter(&connection, adapter_path).await {
-        Err(why) => return Event::DBusError(format!("Unable to get the adapter: {why}")),
+        Err(why) => return Event::DBusError(why),
         Ok(adapter) => adapter,
     };
 
@@ -207,7 +207,7 @@ pub async fn stop_discovery(connection: zbus::Connection, adapter_path: OwnedObj
     }
 
     if let Err(why) = result {
-        return Event::DBusError(why.to_string());
+        return Event::DBusError(why);
     }
     Event::Ok
 }
@@ -242,7 +242,7 @@ pub async fn change_adapter_status(
 
     if let Err(why) = result {
         tracing::error!("Failed to change the adapter state!");
-        return Event::DBusError(why.to_string());
+        return Event::DBusError(why);
     }
 
     Event::Ok
@@ -267,7 +267,7 @@ pub async fn get_adapters(connection: zbus::Connection) -> Event {
         Ok(adapters) => Event::SetAdapters(adapters),
         Err(why) => {
             tracing::error!("dbus connection failed. {why}");
-            Event::DBusError(why.to_string())
+            Event::DBusError(why)
         }
     }
 }

--- a/src/bluetooth/device.rs
+++ b/src/bluetooth/device.rs
@@ -330,7 +330,7 @@ pub async fn get_devices(connection: zbus::Connection, adapter_path: OwnedObject
         Ok(devices) => Event::SetDevices(devices),
         Err(why) => {
             tracing::error!("zbus connection failed. {why}");
-            Event::DBusError(why.to_string())
+            Event::DBusError(why)
         }
     }
 }

--- a/src/bluetooth/mod.rs
+++ b/src/bluetooth/mod.rs
@@ -18,7 +18,7 @@ pub enum Event {
     AddedAdapter(OwnedObjectPath, Adapter),
     AddedDevice(OwnedObjectPath, Device),
     Agent(Arc<bluez_zbus::agent1::Message>),
-    DBusError(String),
+    DBusError(zbus::Error),
     DBusServiceUnknown,
     DeviceFailed(OwnedObjectPath),
     Ok,

--- a/src/bluetooth/mod.rs
+++ b/src/bluetooth/mod.rs
@@ -22,6 +22,7 @@ pub enum Event {
     DBusServiceUnknown,
     DeviceFailed(OwnedObjectPath),
     Ok,
+    NameHasNoOwner,
     RemovedAdapter(OwnedObjectPath),
     RemovedDevice(OwnedObjectPath),
     SetAdapters(HashMap<OwnedObjectPath, Adapter>),

--- a/src/bluetooth/subscription.rs
+++ b/src/bluetooth/subscription.rs
@@ -200,7 +200,7 @@ pub async fn watch(connection: zbus::Connection, mut tx: futures::channel::mpsc:
         if let Err(why) = result {
             _ = tx.send(Event::DBusError(why.clone())).await;
 
-            tracing::error!("failed to watch bluetooth event: {why}.");
+            tracing::error!("failed to watch bluetooth event: {why:?}.");
 
             // Exit if the dbus service is not found.
             if let zbus::Error::FDO(fdo_error) = why {
@@ -210,6 +210,12 @@ pub async fn watch(connection: zbus::Connection, mut tx: futures::channel::mpsc:
                             "The org.bluez dbus service is unknown. Is the bluez service installed and activatable?"
                         );
                         _ = tx.send(Event::DBusServiceUnknown).await;
+                        return;
+                    }
+
+                    fdo::Error::NameHasNoOwner(_) => {
+                        tracing::error!("The org.bluez dbus service is not enabled or active");
+                        _ = tx.send(Event::NameHasNoOwner).await;
                         return;
                     }
 

--- a/src/bluetooth/subscription.rs
+++ b/src/bluetooth/subscription.rs
@@ -198,7 +198,7 @@ pub async fn watch(connection: zbus::Connection, mut tx: futures::channel::mpsc:
         }.await;
 
         if let Err(why) = result {
-            _ = tx.send(Event::DBusError(why.to_string())).await;
+            _ = tx.send(Event::DBusError(why.clone())).await;
 
             tracing::error!("failed to watch bluetooth event: {why}.");
 


### PR DESCRIPTION
- Return zbus::Error instead of strings so that the clients can handle the errors
- End stream when `NameHasNoOwner` error is received, along with an event