### PR TITLE
improve(pipewire): use alsa name for source and sink nodes

### DIFF
--- a/src/pipewire.rs
+++ b/src/pipewire.rs
@@ -110,9 +110,12 @@ impl Device {
     #[must_use]
     pub fn from_node(info: &NodeInfoRef) -> Option<Self> {
         let props = info.props()?;
+        let mut desc_prop_name = "node.description";
 
         let variant =
             if let Some(alsa_card) = props.get("alsa.card").and_then(|v| v.parse::<u32>().ok()) {
+                desc_prop_name = "alsa.name";
+
                 DeviceVariant::Alsa {
                     alsa_card,
                     alsa_card_name: props.get("alsa.card_name")?.to_owned(),
@@ -138,7 +141,7 @@ impl Device {
                 _ => return None,
             },
             node_description: props
-                .get("node.description")?
+                .get(&desc_prop_name)?
                 .replace("High Definition Audio", "HD Audio"),
             node_name: props.get("node.name")?.to_owned(),
             state: match info.state() {


### PR DESCRIPTION
While inspecting the available nodes in pipewire on my machine, I noticed that alsa devices have much more descriptive names provided in the `alsa.name` property.

For example, the name of my monitor displayed in the settings  app changed from `Navi 31 HDMI/DP Audio Digital Stereo (HDMI 2)` to `DELL XXXXX`, which is much more understandable.

I updated the code so that we use the `alsa.name` for alsa devices and `node.description` for all other devices.

Maybe we can remove the logic that shortens the display name now... Maybe ;):
```diff
145                .replace("High Definition Audio", "HD Audio"),
```