### PR TITLE
fix: remove default features for libcosmic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cosmic-settings-subscriptions"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
 [dependencies]
@@ -11,23 +11,23 @@ cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", optiona
 num-derive = { version = "0.4", optional = true }
 num-traits = { version = "0.2", optional = true }
 sctk = { git = "https://github.com/smithay/client-toolkit/", package = "smithay-client-toolkit", optional = true }
-futures = "0.3.30"
+futures = "0.3.31"
 iced_futures = { git = "https://github.com/pop-os/libcosmic" }
 itertools = "0.14.0"
 libcosmic = { git = "https://github.com/pop-os/libcosmic", default-features = false }
-libpulse-binding = { version = "2.29.0", optional = true }
-log = "0.4.22"
+libpulse-binding = { version = "2.30.1", optional = true }
+log = "0.4.27"
 pipewire = { version = "0.8.0", optional = true }
-rustix = { version = "1.0.0", optional = true }
+rustix = { version = "1.0.8", optional = true }
 secure-string = { version = "0.3.0", optional = true }
-thiserror = "2.0.0"
-tokio = { version = "1.39.3", features = ["net", "process", "sync"] }
-tokio-stream = "0.1.15"
-tracing = "0.1.40"
+thiserror = "2.0.16"
+tokio = { version = "1.47.1", features = ["net", "process", "sync"] }
+tokio-stream = "0.1.17"
+tracing = "0.1.41"
 upower_dbus = { git = "https://github.com/pop-os/dbus-settings-bindings", optional = true }
 bluez-zbus = { git = "https://github.com/pop-os/dbus-settings-bindings", optional = true }
-zbus = "5.7.1"
-indexmap = { version = "2.10.0", optional = true }
+zbus = "5.10.0"
+indexmap = { version = "2.11.0", optional = true }
 async-fn-stream = "0.2.2"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ sctk = { git = "https://github.com/smithay/client-toolkit/", package = "smithay-
 futures = "0.3.30"
 iced_futures = { git = "https://github.com/pop-os/libcosmic" }
 itertools = "0.14.0"
-libcosmic = { git = "https://github.com/pop-os/libcosmic" }
+libcosmic = { git = "https://github.com/pop-os/libcosmic", default-features = false }
 libpulse-binding = { version = "2.29.0", optional = true }
 log = "0.4.22"
 pipewire = { version = "0.8.0", optional = true }

--- a/src/accessibility/mod.rs
+++ b/src/accessibility/mod.rs
@@ -3,8 +3,8 @@
 
 use cosmic_dbus_a11y::*;
 use futures::FutureExt;
-use futures::{self, select, SinkExt, StreamExt};
-use iced_futures::{stream, Subscription};
+use futures::{self, SinkExt, StreamExt, select};
+use iced_futures::{Subscription, stream};
 use std::fmt::Debug;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use zbus::Connection;

--- a/src/airplane_mode/rfkill.rs
+++ b/src/airplane_mode/rfkill.rs
@@ -34,8 +34,8 @@ pub struct DeviceState {
     pub hard: bool,
 }
 
-pub fn rfkill_updates(
-) -> io::Result<impl Stream<Item = io::Result<HashMap<u32, DeviceState>>> + Unpin> {
+pub fn rfkill_updates()
+-> io::Result<impl Stream<Item = io::Result<HashMap<u32, DeviceState>>> + Unpin> {
     struct State {
         file: AsyncFd<fs::File>,
         devices: HashMap<u32, DeviceState>,

--- a/src/cosmic_a11y_manager/mod.rs
+++ b/src/cosmic_a11y_manager/mod.rs
@@ -2,12 +2,12 @@ use cosmic_protocols::a11y::v1::client::cosmic_a11y_manager_v1::{self, ActiveSta
 use num_derive::{FromPrimitive, ToPrimitive};
 use sctk::{
     reexports::{
-        calloop::{self, channel, LoopSignal},
+        calloop::{self, LoopSignal, channel},
         calloop_wayland_source::WaylandSource,
         client::{
-            globals::{registry_queue_init, GlobalListContents},
-            protocol::wl_registry,
             ConnectError, Connection, Dispatch, Proxy, WEnum,
+            globals::{GlobalListContents, registry_queue_init},
+            protocol::wl_registry,
         },
     },
     registry::RegistryState,

--- a/src/network_manager/active_conns.rs
+++ b/src/network_manager/active_conns.rs
@@ -4,7 +4,7 @@
 use super::Event;
 use cosmic_dbus_networkmanager::nm::NetworkManager;
 use futures::{SinkExt, StreamExt};
-use iced_futures::{stream, Subscription};
+use iced_futures::{Subscription, stream};
 use std::{fmt::Debug, hash::Hash};
 use zbus::Connection;
 

--- a/src/network_manager/devices.rs
+++ b/src/network_manager/devices.rs
@@ -8,9 +8,9 @@ pub use cosmic_dbus_networkmanager::interface::enums::{
 
 use cosmic_dbus_networkmanager::nm::NetworkManager;
 use futures::{SinkExt, StreamExt};
-use iced_futures::{self, stream, Subscription};
+use iced_futures::{self, Subscription, stream};
 use std::{fmt::Debug, hash::Hash, sync::Arc};
-use zbus::{zvariant::ObjectPath, Connection};
+use zbus::{Connection, zvariant::ObjectPath};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct DeviceInfo {

--- a/src/network_manager/mod.rs
+++ b/src/network_manager/mod.rs
@@ -25,18 +25,18 @@ use cosmic_dbus_networkmanager::{
     settings::NetworkManagerSettings,
 };
 use futures::{
-    channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
     FutureExt, SinkExt, StreamExt,
+    channel::mpsc::{UnboundedReceiver, UnboundedSender, unbounded},
 };
 use hw_address::HwAddress;
-use iced_futures::{stream, Subscription};
+use iced_futures::{Subscription, stream};
 use secure_string::SecureString;
 use tokio::process::Command;
 use zbus::zvariant::{self, ObjectPath, Value};
 
 use self::{
-    available_wifi::{handle_wireless_device, AccessPoint},
-    current_networks::{active_connections, ActiveConnectionInfo},
+    available_wifi::{AccessPoint, handle_wireless_device},
+    current_networks::{ActiveConnectionInfo, active_connections},
 };
 
 pub type SSID = Arc<str>;

--- a/src/network_manager/wireless_enabled.rs
+++ b/src/network_manager/wireless_enabled.rs
@@ -4,7 +4,7 @@
 use super::Event;
 use cosmic_dbus_networkmanager::nm::NetworkManager;
 use futures::{SinkExt, StreamExt};
-use iced_futures::{stream, Subscription};
+use iced_futures::{Subscription, stream};
 use std::{fmt::Debug, hash::Hash};
 use zbus::Connection;
 

--- a/src/pipewire.rs
+++ b/src/pipewire.rs
@@ -5,8 +5,8 @@
 
 pub use pipewire::channel::Sender;
 
-use futures::{executor::block_on, SinkExt};
-use iced_futures::{stream, Subscription};
+use futures::{SinkExt, executor::block_on};
+use iced_futures::{Subscription, stream};
 use pipewire::{
     context::Context as PwContext,
     main_loop::MainLoop as PwMainLoop,

--- a/src/pulse.rs
+++ b/src/pulse.rs
@@ -4,15 +4,15 @@
 // Make sure not to fail if pulse not found, and reconnect?
 // change to device shouldn't send osd?
 
-use futures::{executor::block_on, SinkExt};
-use iced_futures::{stream, Subscription};
+use futures::{SinkExt, executor::block_on};
+use iced_futures::{Subscription, stream};
 use libpulse_binding::{
     callbacks::ListResult,
     channelmap::Map,
     context::{
+        Context, FlagSet, State,
         introspect::{CardInfo, CardProfileInfo, Introspector, ServerInfo, SinkInfo, SourceInfo},
         subscribe::{Facility, InterestMaskSet, Operation},
-        Context, FlagSet, State,
     },
     def::{PortAvailable, Retval},
     mainloop::{

--- a/src/settings_daemon.rs
+++ b/src/settings_daemon.rs
@@ -5,7 +5,7 @@
 
 use futures::{FutureExt, StreamExt};
 use iced_futures::Subscription;
-use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
+use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 pub fn subscription(connection: zbus::Connection) -> iced_futures::Subscription<Event> {

--- a/src/upower/kbdbacklight.rs
+++ b/src/upower/kbdbacklight.rs
@@ -7,7 +7,7 @@
 use futures::{FutureExt, Stream, StreamExt};
 use iced_futures::Subscription;
 use std::{fmt::Debug, hash::Hash};
-use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
+use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use upower_dbus::{BrightnessChanged, KbdBacklightProxy};
 


### PR DESCRIPTION
This pulled in `iced_accessibility`, which causes applets to crash.

Noticed that applets sometimes crashed after the Rust 2024 update (which updated subscriptions), especially when `cosmic-initial-setup` is launched, and the addition of the libcosmic dependency with default features here seems to be the cause.